### PR TITLE
CDI duplicate lookup fix

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
@@ -181,15 +181,16 @@ public final class Providers {
      * @return iterable of all available ranked service providers for the contract. Return value is never {@code null}.
      */
     public static <T> Iterable<RankedProvider<T>> getAllRankedProviders(InjectionManager injectionManager, Class<T> contract) {
-        List<ServiceHolder<T>> providers = getServiceHolders(injectionManager, contract, CustomAnnotationLiteral.INSTANCE);
+        final List<ServiceHolder<T>> providers = getServiceHolders(injectionManager, contract, CustomAnnotationLiteral.INSTANCE);
         providers.addAll(getServiceHolders(injectionManager, contract));
 
-        LinkedHashMap<ServiceHolder<T>, RankedProvider<T>> providerMap = new LinkedHashMap<>();
+        final LinkedHashMap<Class<T>, RankedProvider<T>> providerMap = new LinkedHashMap<>();
 
-        for (ServiceHolder<T> provider : providers) {
-            if (!providerMap.containsKey(provider)) {
+        for (final ServiceHolder<T> provider : providers) {
+            final Class<T> implClass = getImplementationClass(contract, provider);
+            if (!providerMap.containsKey(implClass)) {
                 Set<Type> contracts = isProxyGenerated(contract, provider) ? provider.getContractTypes() : null;
-                providerMap.put(provider, new RankedProvider<>(provider.getInstance(), provider.getRank(), contracts));
+                providerMap.put(implClass, new RankedProvider<>(provider.getInstance(), provider.getRank(), contracts));
             }
         }
 
@@ -283,14 +284,16 @@ public final class Providers {
                                                              CustomAnnotationLiteral.INSTANCE);
         providers.addAll(getServiceHolders(injectionManager, contract, Comparator.comparingInt(Providers::getPriority)));
 
-        LinkedHashSet<ServiceHolder<T>> providersSet = new LinkedHashSet<>();
-        for (ServiceHolder<T> provider : providers) {
-            if (!providersSet.contains(provider)) {
-                providersSet.add(provider);
+        final LinkedHashMap<Class<T>, ServiceHolder<T>> providerMap = new LinkedHashMap<>();
+
+        for (final ServiceHolder<T> provider : providers) {
+            final Class<T> implClass = getImplementationClass(contract, provider);
+            if (!providerMap.containsKey(implClass)) {
+                providerMap.put(implClass, provider);
             }
         }
 
-        return providersSet;
+        return providerMap.values();
     }
 
     private static <T> List<ServiceHolder<T>> getServiceHolders(

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
@@ -312,7 +312,7 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
                 : new GenericCdiBeanSupplier(clazz, injectionManager, beanManager, isCdiManaged);
 
         SupplierInstanceBinding<AbstractCdiBeanSupplier> builder = Bindings.supplier(beanFactory)
-                .to(clazz);
+                .to(clazz).qualifiedBy(CustomAnnotationLiteral.INSTANCE);
         for (final Class contract : providerContracts) {
             builder.to(contract);
         }


### PR DESCRIPTION
Actually custom CDI components shall be marked as custom. Which was  attempted at aa8020a3. However this discovered another issue (which was not originally noticed) that 
**Providers** class redundantly calls _getServiceHolders_ method:

```
List<ServiceHolder<T>> providers = getServiceHolders(injectionManager, contract, CustomAnnotationLiteral.INSTANCE);
providers.addAll(getServiceHolders(injectionManager, contract));

```
the first call (_getServiceHolders(injectionManager, contract, CustomAnnotationLiteral.INSTANCE)_) is never effective - it always returns 0 whether custom provider is annotated with Custom or not (I am talking about the original code before aa8020a3 without _.qualifiedBy(CustomAnnotationLiteral.INSTANCE)_ in the **CdiComponentProvider** class). 

On the other hand the call to _getServiceHolders(injectionManager, contract)_ always returns ALL providers independently of annotation. 

when the line _.qualifiedBy(CustomAnnotationLiteral.INSTANCE)_  was introduced in aa8020a3 the call of _getServiceHolders(injectionManager, contract, CustomAnnotationLiteral.INSTANCE);_ started to work. Thus duplicate appears. 

So, the solution is to call _getServiceHolders(injectionManager, contract)_ only once without referring to annotation mark. 

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>